### PR TITLE
Fix #164: serve ignores missing files

### DIFF
--- a/mkdocs/build.py
+++ b/mkdocs/build.py
@@ -9,6 +9,9 @@ import jinja2
 import json
 import markdown
 import os
+import logging
+
+log = logging.getLogger('mkdocs')
 
 
 def convert_markdown(markdown_source, site_navigation=None, extensions=()):
@@ -159,7 +162,10 @@ def build_pages(config, dump_json=False):
     for page in site_navigation.walk_pages():
         # Read the input file
         input_path = os.path.join(config['docs_dir'], page.input_path)
-        input_content = open(input_path, 'r').read()
+        try:
+            input_content = open(input_path, 'r').read()
+        except IOError:
+            log.error('file not found: %s' % input_path)
         if PY2:
             input_content = input_content.decode('utf-8')
 

--- a/mkdocs/config.py
+++ b/mkdocs/config.py
@@ -4,8 +4,11 @@ from mkdocs import utils
 from mkdocs.compat import urlparse
 from mkdocs.exceptions import ConfigurationError
 
+import logging
 import os
 import yaml
+
+log = logging.getLogger(__name__)
 
 DEFAULT_CONFIG = {
     'site_name': None,

--- a/mkdocs/main.py
+++ b/mkdocs/main.py
@@ -2,6 +2,7 @@
 # coding: utf-8
 from __future__ import print_function
 
+import logging
 import sys
 
 from mkdocs.build import build
@@ -10,6 +11,16 @@ from mkdocs.exceptions import ConfigurationError
 from mkdocs.gh_deploy import gh_deploy
 from mkdocs.new import new
 from mkdocs.serve import serve
+
+
+def configure_logging(options):
+    '''When a --verbose flag is passed, increase the verbosity of mkdocs'''
+    logger = logging.getLogger('mkdocs')
+    logger.addHandler(logging.StreamHandler())
+    if 'verbose' in options:
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.WARNING)
 
 
 def arg_to_option(arg):
@@ -27,6 +38,7 @@ def main(cmd, args, options=None):
     """
     Build the documentation, and optionally start the devserver.
     """
+    configure_logging(options)
     clean_site_dir = 'clean' in options
     if cmd == 'serve':
         config = load_config(options=options)

--- a/mkdocs/test.py
+++ b/mkdocs/test.py
@@ -5,6 +5,7 @@
 from mkdocs import build, main, nav, toc, utils, config
 from mkdocs.compat import PY2, zip
 from mkdocs.exceptions import ConfigurationError
+import logging
 import markdown
 import os
 import shutil
@@ -38,6 +39,16 @@ class MainTests(unittest.TestCase):
         arg, option = main.arg_to_option('--use_directory_urls')
         self.assertEqual('use_directory_urls', arg)
         self.assertEqual(True, option)
+
+    def test_configure_logging(self):
+        """
+        Check that logging is configured correctly
+        """
+        logger = logging.getLogger('mkdocs')
+        main.configure_logging({})
+        self.assertEqual(logging.WARNING, logger.level)
+        main.configure_logging({'verbose': True})
+        self.assertEqual(logging.DEBUG, logger.level)
 
 
 class ConfigTests(unittest.TestCase):


### PR DESCRIPTION
We log an error about the missing file, and skip building of that page.
The logging is simplified here, and should be updated along with #172 