### PR TITLE
Added build datetime to context

### DIFF
--- a/docs/user-guide/styling-your-docs.md
+++ b/docs/user-guide/styling-your-docs.md
@@ -46,3 +46,19 @@ How to style and theme your documentation.
 ![Yeti](http://bootswatch.com/yeti/thumbnail.png)
 
 ## Custom themes
+
+### Context variables
+
+The following context variables are available to your custom templates:
+
+- ``build_date`` - a datetime object. You can render the build date of your documentation in a template using jinja 2 syntax. e.g. ``{{ build_date.strftime('%Y-%m-%d') }}``
+- ``site_name`` - string
+- ``site_author`` - string
+- ``favicon`` - string
+- ``page_description`` - string
+- ``nav`` - string
+- ``homepage_url``- string
+- ``extra_css`` - string
+- ``extra_javascript`` - string
+- ``base_url`` - string
+- ``copyright`` - string

--- a/mkdocs/build.py
+++ b/mkdocs/build.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from __future__ import print_function
 
+import datetime
 from jinja2.exceptions import TemplateNotFound
 from mkdocs import nav, toc, utils
 from mkdocs.compat import urljoin, PY2
@@ -87,6 +88,7 @@ def get_global_context(nav, config):
         'include_search': config['include_search'],
 
         'copyright': config['copyright'],
+        'build_date': datetime.datetime.now(),
         'google_analytics': config['google_analytics']
     }
 


### PR DESCRIPTION
Useful to know when the docs were last built. Datetime format can be controlled in the template like so:

``{{ build_date.strftime('%Y-%m-%d') }}``