### PR TITLE
Update base.html

### DIFF
--- a/mkdocs/themes/readthedocs/base.html
+++ b/mkdocs/themes/readthedocs/base.html
@@ -18,8 +18,8 @@
   <link href="{{ path }}" rel="stylesheet">
   {%- endfor %}
 
-  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
+  <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+  <script src="http://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
   <script type="text/javascript" src="{{ base_url }}/js/highlight.pack.js"></script>
   <script src="{{ base_url }}/js/theme.js"></script>
   {%- for path in extra_javascript %}


### PR DESCRIPTION
d0ugal marked #324 closed because of something to do with with a previous discussion about local store. That said: this templates src URLs are still "broken" (a bug) for non-HTTP-served content. 

It is just a reference error that only shows up when "http:" is not the default protocol to be handled -- i.e. when not being served. An alternative to this 'fix': store jquery and modernizr within the template directory structure itself and update this path reference to use {{base_url}}.