### PR TITLE
removes TOC tag creation

### DIFF
--- a/mkdocs/build.py
+++ b/mkdocs/build.py
@@ -24,9 +24,6 @@ def convert_markdown(markdown_source, site_navigation=None, extensions=(), stric
     to the default set.
     """
 
-    # Prepend a table of contents marker for the TOC extension
-    markdown_source = toc.pre_process(markdown_source)
-
     # Generate the HTML from the markdown source
     builtin_extensions = ['meta', 'toc', 'tables', 'fenced_code']
     mkdocs_extensions = [RelativePathExtension(site_navigation, strict), ]
@@ -36,9 +33,7 @@ def convert_markdown(markdown_source, site_navigation=None, extensions=(), stric
     )
     html_content = md.convert(markdown_source)
     meta = md.Meta
-
-    # Strip out the generated table of contents
-    (html_content, toc_html) = toc.post_process(html_content)
+    toc_html = md.toc
 
     # Post process the generated table of contents into a data structure
     table_of_contents = toc.TableOfContents(toc_html)

--- a/mkdocs/test.py
+++ b/mkdocs/test.py
@@ -711,8 +711,20 @@ class BuildTests(unittest.TestCase):
         docs_dir = tempfile.mkdtemp()
         site_dir = tempfile.mkdtemp()
         try:
-            # Create a markdown file, image, dot file and dot directory.
-            open(os.path.join(docs_dir, 'index.md'), 'w').close()
+            # Create a non-empty markdown file, image, dot file and dot directory.
+            f = open(os.path.join(docs_dir, 'index.md'), 'w')
+            f.write(dedent("""
+                page_title: custom title
+
+                # Heading 1
+
+                This is some text.
+
+                # Heading 2
+
+                And some more text.
+            """))
+            f.close()
             open(os.path.join(docs_dir, 'img.jpg'), 'w').close()
             open(os.path.join(docs_dir, '.hidden'), 'w').close()
             os.mkdir(os.path.join(docs_dir, '.git'))

--- a/mkdocs/test.py
+++ b/mkdocs/test.py
@@ -178,7 +178,6 @@ class UtilsTests(unittest.TestCase):
 class TableOfContentsTests(unittest.TestCase):
     def markdown_to_toc(self, markdown_source):
         md = markdown.Markdown(extensions=['toc'])
-        html_output = md.convert(markdown_source)
         toc_output = md.toc
         return toc.TableOfContents(toc_output)
 

--- a/mkdocs/test.py
+++ b/mkdocs/test.py
@@ -177,10 +177,9 @@ class UtilsTests(unittest.TestCase):
 
 class TableOfContentsTests(unittest.TestCase):
     def markdown_to_toc(self, markdown_source):
-        markdown_source = toc.pre_process(markdown_source)
         md = markdown.Markdown(extensions=['toc'])
         html_output = md.convert(markdown_source)
-        html_output, toc_output = toc.post_process(html_output)
+        toc_output = md.toc
         return toc.TableOfContents(toc_output)
 
     def test_indented_toc(self):
@@ -549,7 +548,7 @@ class BuildTests(unittest.TestCase):
             '../img/initial-layout.png',
         )
 
-        template = '<p><img alt="The initial MkDocs layout" src="%s" /></p>\n'
+        template = '<p><img alt="The initial MkDocs layout" src="%s" /></p>'
 
         for (page, expected) in zip(site_navigation.walk_pages(), expected_results):
             md_text = '![The initial MkDocs layout](img/initial-layout.png)'
@@ -572,7 +571,7 @@ class BuildTests(unittest.TestCase):
             '../../img/initial-layout.png',
         )
 
-        template = '<p><img alt="The initial MkDocs layout" src="%s" /></p>\n'
+        template = '<p><img alt="The initial MkDocs layout" src="%s" /></p>'
 
         for (page, expected) in zip(site_navigation.walk_pages(), expected_results):
             md_text = '![The initial MkDocs layout](/img/initial-layout.png)'
@@ -612,7 +611,7 @@ class BuildTests(unittest.TestCase):
         for page in site_navigation.walk_pages():
             markdown = '[test](#test)'
             html, _, _ = build.convert_markdown(markdown, site_navigation=site_navigation)
-            self.assertEqual(html, '<p><a href="#test">test</a></p>\n')
+            self.assertEqual(html, '<p><a href="#test">test</a></p>')
 
     def test_ignore_external_link(self):
         md_text = 'An [external link](http://example.com/external.md).'

--- a/mkdocs/test.py
+++ b/mkdocs/test.py
@@ -178,6 +178,7 @@ class UtilsTests(unittest.TestCase):
 class TableOfContentsTests(unittest.TestCase):
     def markdown_to_toc(self, markdown_source):
         md = markdown.Markdown(extensions=['toc'])
+        md.convert(markdown_source)
         toc_output = md.toc
         return toc.TableOfContents(toc_output)
 

--- a/mkdocs/toc.py
+++ b/mkdocs/toc.py
@@ -16,25 +16,7 @@ The steps we take to generate a table of contents are:
 
 import re
 
-TOC_DELIMITER = '<!-- STARTTOC -->'
 TOC_LINK_REGEX = re.compile('<a href=["]([^"]*)["]>([^<]*)</a>')
-
-
-def pre_process(markdown_content):
-    """
-    Append a `[TOC]` marker to the markdown.
-    The `toc` extension injects the HTML table of contents here.
-    """
-    return markdown_content + '\n\n' + TOC_DELIMITER + '\n[TOC]'
-
-
-def post_process(html_content):
-    """
-    Strip the generated HTML table of contents from the HTML output.
-
-    Returns a two-tuple of `(content, table_of_contents)`
-    """
-    return html_content.rsplit(TOC_DELIMITER, 1)
 
 
 class TableOfContents(object):


### PR DESCRIPTION
The [documentation for the toc extension](https://pythonhosted.org/Markdown/extensions/toc.html) states:
>If a marker is not found in the document, then the Table of Contents is available as an attribute of the Markdown class.

I refactored toc.py and build.py accordingly. Local tox testing showed newline differences in some tests due to my refactoring, I also adapted these tests.
A remaining issue is that test_copying_media errors out and I can't find the reason why. [Trace is here](https://gist.github.com/anonymous/db5dfa1b82fcc010c170).