### PR TITLE
First stab at custom theme documentation

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -121,21 +121,7 @@ Sets the theme of your documentation site, for a list of available themes visit
 
 Lets you set a directory to a custom theme.  This can either be a relative directory, in which case it is resolved relative to the directory containing you configuration file, or it can be an absolute directory path.
 
-For example, given this example project layout:
-
-    mkdocs.yml
-    docs/
-        index.md
-        about.md
-    custom_theme/
-        base.html
-        ...
-
-You would include the following setting to use the custom theme directory:
-
-    theme_dir: 'custom_theme'
-
-If used in combination with the `theme` configuration value a custom theme can be used to replace only specific parts of a themes templates. For example, with the above layout and if you set your `theme: mkdocs` then the base.html file would replace that in the theme but otherwise it would remain the same. This is useful if you want to make small adjustments to an existing theme.
+See [styling your docs](styling-your-docs.md#custom-themes) for an explanation of custom themes.
 
 **default**: `null`
 

--- a/docs/user-guide/styling-your-docs.md
+++ b/docs/user-guide/styling-your-docs.md
@@ -41,3 +41,32 @@ How to style and theme your documentation.
 ![Yeti](http://bootswatch.com/yeti/thumbnail.png)
 
 ## Custom themes
+
+The bare minimum required for a custom theme is a `base.html` template file. This should be placed in a directory at the same level as the `mkdocs.yml` configuration file. Within `mkdocs.yml`, specify the `theme_dir` option and set it to the name of the directory containing `base.html`. For example, given this example project layout:
+
+    mkdocs.yml
+    docs/
+        index.md
+        about.md
+    custom_theme/
+        base.html
+        ...
+
+You would include the following setting to use the custom theme directory:
+
+    theme_dir: 'custom_theme'
+
+If used in combination with the `theme` configuration value a custom theme can be used to replace only specific parts of a built-in theme. For example, with the above layout and if you set `theme: mkdocs` then the `base.html` file would replace that in the theme but otherwise it would remain the same. This is useful if you want to make small adjustments to an existing theme.
+
+The simplest `base.html` file is the following:
+
+    <!DOCTYPE html>
+    <html>
+      <head>
+      </head>
+      <body>
+        {{ content }}
+      </body>
+    </html>
+
+Article content from each page specified in `mkdocs.yml` is inserted using the `{{ content }}` tag. Stylesheets and scripts can be brought into this theme as with a normal HTML file. Navbars and tables of contents can also be generated and included automatically, through the `nav` and `toc` objects, respectively. If you wish to write your own theme, it is recommended to start with one of the [built-in themes](https://github.com/tomchristie/mkdocs/tree/master/mkdocs/themes) and modify it accordingly.


### PR DESCRIPTION
I moved the custom theme discussion from the configuration page to the styling-your-docs page and expanded on it a little. Perhaps we should expand on the navbar and toc generation too. See #181.