### PR TITLE
Have slash at end of all page links

### DIFF
--- a/mkdocs/nav.py
+++ b/mkdocs/nav.py
@@ -98,10 +98,10 @@ class URLContext(object):
                 # Workaround for static assets
                 return '.'
             return url.lstrip('/')
-        relative_path = posixpath.relpath(url, start=self.base_path) + suffix
-
         # Under Python 2.6, relative_path adds an extra '/' at the end.
-        return relative_path.rstrip('/')
+        relative_path = posixpath.relpath(url, start=self.base_path).rstrip('/') + suffix
+
+        return relative_path
 
 
 class FileContext(object):

--- a/mkdocs/test.py
+++ b/mkdocs/test.py
@@ -417,6 +417,16 @@ class SiteNavigationTests(unittest.TestCase):
         base_url = site_navigation.url_context.make_relative('/')
         self.assertEqual(base_url, '.')
 
+    def test_relative_md_links_have_slash(self):
+        pages = [
+            ('index.md',),
+            ('user-guide/styling-your-docs.md',)
+        ]
+        site_navigation = nav.SiteNavigation(pages, use_directory_urls=False)
+        site_navigation.url_context.base_path = "/user-guide/configuration"
+        url = site_navigation.url_context.make_relative('/user-guide/styling-your-docs/')
+        self.assertEqual(url, '../styling-your-docs/')
+
     def test_generate_site_navigation(self):
         """
         Verify inferring page titles based on the filename


### PR DESCRIPTION
As discussed in https://github.com/rtfd/readthedocs.org/issues/1101, this makes directory links consistently have a trailing slash.

It looks like the fix for Python 2.6 in https://github.com/tomchristie/mkdocs/commit/f437ab058532851b369139e8ad261fbaee684448 could strip off `suffix` in addition to the additional `/` it was meant to remove - I've just switched the order so that `suffix` is appended after `rstrip('/')` is called.

I've also added a test (which failed without my fix).