### PR TITLE
add documentation to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 recursive-include mkdocs/themes *.ico *.js *.css *.png *.html *.eot *.svg *.ttf *.woff
+include mkdocs.yml
+recursive-include docs *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]


### PR DESCRIPTION
When creating packages or installing from source it's good to have the
option of using the documentation provided with that code base.

I'm not sure if I've included the correct scope of items (really wasn't
sure about docs/CNAME) so if I need to edit this commit; please, let me
know.