### PR TITLE
fixed loading jquery.min.js and modernizr.min.js with readthedocs theme

### DIFF
--- a/mkdocs/themes/readthedocs/base.html
+++ b/mkdocs/themes/readthedocs/base.html
@@ -18,8 +18,8 @@
   <link href="{{ path }}" rel="stylesheet">
   {%- endfor %}
 
-  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
+  <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+  <script src="http://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
   <script type="text/javascript" src="{{ base_url }}/js/highlight.pack.js"></script>
   <script src="{{ base_url }}/js/theme.js"></script>
   {%- for path in extra_javascript %}


### PR DESCRIPTION
fixed loading jquery.min.js and modernizr.min.js with readthedocs theme when runing built html doc from file (i.e. file:///..../index.html)